### PR TITLE
Issue #3 - Allowed the ability to use the old basket format for Sage …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,66 @@ You must disable CSRF protection for the incoming requests, assuming it is enabl
 
 A clean example for how to go about this can be found [here](https://craftcms.stackexchange.com/a/20301/258).
 
+
+## Using Old Basket Format
+
+SagePay has two methods to submit the basket, `Basket` and `BasketXML`.  Read more from the `thephpleague/omnipay-sagepay` docs [here](https://github.com/thephpleague/omnipay-sagepay#basket-format).
+
+If you need Sage 50 Accounts Integration you will need to use the Basket Format and you can read more about the integration [here](https://github.com/thephpleague/omnipay-sagepay#sage-50-accounts-software-integration).
+
+### Implementing Basket Format in Craft with Sage 50 Accounts Integration
+
+Create the a config file named `config/commerce-gateways.php` if you yet already don't have one and then insert the following config to enable the `Basket` format. 
+
+```
+<?php
+return [
+    '<your-sagepay-handle>' => [
+        'useOldBasketFormat' => true
+    ],
+];
+```
+
+
+To then add the Product Code for the Sage 50 Account Integration you can hook into the following event:
+
+```
+\craft\commerce\omnipay\base\Gateway::EVENT_AFTER_CREATE_ITEM_BAG
+```
+
+Like so:
+
+```
+Event::on(\craft\commerce\omnipay\base\Gateway::class, \craft\commerce\omnipay\base\Gateway::EVENT_AFTER_CREATE_ITEM_BAG, function(ItemBagEvent $itemBagEvent) {
+    
+    $orderLineItems = $itemBagEvent->order->getLineItems();
+
+    /**
+     * @var $item Item
+    */
+    foreach ($itemBagEvent->items as $key => $item) {
+
+        if (!isset($orderLineItems[$key])) {
+            return;
+        }
+
+        $orderLineItem  = $orderLineItems[$key];
+
+        // We validate that the description and price are the same as we are relying upon the order
+        // of the Order Items and The OmniPay Item Bag to be the same
+        if ($orderLineItem->getDescription() != $item->getDescription()) {
+            return;
+        }
+
+        if ($orderLineItem->price != $item->getPrice()) {
+            return;
+        }
+
+        $sku = $orderLineItem->getSku();
+
+        // Place the SKU within [] as the Product Record for the Sage 50 Accounts Integration
+        $description = '[' . $sku . ']' . $item->getDescription();
+        $item->setDescription($description);
+    }
+});
+```

--- a/src/gateways/Direct.php
+++ b/src/gateways/Direct.php
@@ -43,6 +43,13 @@ class Direct extends CreditCardGateway
      */
     public $sendCartInfo = false;
 
+    /**
+     * SagePay supports two formats, Basket and BasketXML. Basket is legacy format. Read more here:
+     * https://github.com/thephpleague/omnipay-sagepay#basket-format
+     * @var bool
+     */
+    public $useOldBasketFormat = false;
+
     // Public Methods
     // =========================================================================
 
@@ -107,6 +114,7 @@ class Direct extends CreditCardGateway
         $gateway->setVendor($this->vendor);
         $gateway->setTestMode($this->testMode);
         $gateway->setReferrerId($this->referrerId);
+        $gateway->setUseOldBasketFormat($this->useOldBasketFormat);
 
         return $gateway;
     }

--- a/src/gateways/Server.php
+++ b/src/gateways/Server.php
@@ -49,6 +49,13 @@ class Server extends OffsiteGateway
      */
     public $sendCartInfo = false;
 
+    /**
+     * SagePay supports two formats, Basket and BasketXML. Basket is legacy format. Read more here:
+     * https://github.com/thephpleague/omnipay-sagepay#basket-format
+     * @var bool
+     */
+    public $useOldBasketFormat = false;
+
     // Public Methods
     // =========================================================================
 
@@ -190,6 +197,7 @@ class Server extends OffsiteGateway
         $gateway->setVendor($this->vendor);
         $gateway->setTestMode($this->testMode);
         $gateway->setReferrerId($this->referrerId);
+        $gateway->setUseOldBasketFormat($this->useOldBasketFormat);
 
         return $gateway;
     }


### PR DESCRIPTION
These are the changes required to allow for the Sage 50 Accounts integration by allowing to specify the Gateway to use the `Basket` format instead of the `BasketXML` format through the config.

We currently don't have the capacity to add this to the payment gateways setting config within the admin area but we have added cohesive documentation on how to do this in the README along with the Sage 50 Accounts Integration using Craft Commerce's events.

I've also raised a PR to fix an issue on `2.x` on the `omnipay/sagepay` plugin to allow the basket format support - https://github.com/thephpleague/omnipay-sagepay/pull/109 which should be tagged and release soon.

Would it be possible for this to get reviewed and if acceptable merged as a matter of priority once our changes are in the `2.x` branch in `omnipay/sagepay` as this is currently breaking our clients offline processes.